### PR TITLE
fix to deprecated function call

### DIFF
--- a/teneto/utils/utils.py
+++ b/teneto/utils/utils.py
@@ -516,7 +516,9 @@ def get_distance_function(requested_metric):
         'hamming': distance.hamming,
         'jaccard': distance.jaccard,
         'kulsinski': distance.kulsinski,
-        'matching': distance.matching,
+        # 'distance.matching' is deprecated since scipy version 1.0.0 and was removed in version 1.9.0.
+        # It was an alias of 'distance.hamming', which should be used instead.
+        'matching': distance.hamming,
         'rogerstanimoto': distance.rogerstanimoto,
         'russellrao': distance.russellrao,
         'sokalmichener': distance.sokalmichener,


### PR DESCRIPTION
Call to 'distance.matching' in utils.py is changed to 'distance.hamming', as 'distance.matching' was removed from scipy in version 1.9.0 and 'distance.matching' was just an alias of 'distance.hamming'.